### PR TITLE
STIBCLOUD-53: Render error page in preferred langauge if available on resolved site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jahia.modules</groupId>
 		<artifactId>jahia-modules</artifactId>
-		<version>8.0.0.0</version>
+		<version>8.1.3.1</version>
 	</parent>
 	<groupId>org.jahia.community</groupId>
 	<artifactId>site-settings-error-pages</artifactId>
@@ -23,7 +23,20 @@
 		<jahia-module-type>module</jahia-module-type>
 		<jahia-depends>default</jahia-depends>
 		<require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
+		<jahia.plugin.version>6.10</jahia.plugin.version>
 	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>9</source>
+					<target>9</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<developers>
 		<developer>
 			<name>BEN AJIBA Youssef</name>

--- a/src/main/java/org/jahia/modules/errorpages/handler/ErrorPageHandler.java
+++ b/src/main/java/org/jahia/modules/errorpages/handler/ErrorPageHandler.java
@@ -1,21 +1,9 @@
 package org.jahia.modules.errorpages.handler;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import javax.jcr.AccessDeniedException;
-import javax.jcr.ItemNotFoundException;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.RepositoryException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.api.Constants;
 import org.jahia.bin.errors.ErrorHandler;
-import org.jahia.exceptions.JahiaBadRequestException;
-import org.jahia.exceptions.JahiaNotFoundException;
-import org.jahia.exceptions.JahiaRuntimeException;
-import org.jahia.exceptions.JahiaUnauthorizedException;
+import org.jahia.exceptions.*;
 import org.jahia.modules.errorpages.ErrorPageRequestWrapper;
 import org.jahia.modules.errorpages.service.ErrorPageService;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -23,15 +11,25 @@ import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.content.JCRTemplate;
 import org.jahia.services.content.decorator.JCRSiteNode;
-import org.jahia.services.render.RenderContext;
-import org.jahia.services.render.RenderException;
-import org.jahia.services.render.RenderService;
-import org.jahia.services.render.Resource;
-import org.jahia.services.render.TemplateNotFoundException;
-import org.jahia.services.render.URLResolver;
-import org.jahia.services.render.URLResolverFactory;
+import org.jahia.services.render.*;
+import org.jahia.services.sites.JahiaSite;
+import org.jahia.services.sites.JahiaSitesService;
 import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * capture rendering exceptions and redirect them to custom error pages 400, 401, 403, 404, 500
@@ -40,9 +38,10 @@ import org.slf4j.Logger;
  */
 public class ErrorPageHandler implements ErrorHandler {
 
-    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ErrorPageHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorPageHandler.class);
     private URLResolverFactory urlResolverFactory;
     private ErrorPageService errorPageService;
+    private JahiaSitesService siteService;
 
     @Override
     public boolean handle(Throwable e, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
@@ -78,13 +77,12 @@ public class ErrorPageHandler implements ErrorHandler {
             String sitePath = null;
             if (urlResolver.getSiteInfo() != null) {
                 sitePath = urlResolver.getSiteInfo().getSitePath();
+            } else {
+                sitePath = siteService.getDefaultSite().getJCRLocalPath();
             }
             if (StringUtils.isNotBlank(sitePath)) {
-                boolean system = false;
-                if (code == HttpServletResponse.SC_UNAUTHORIZED || code == HttpServletResponse.SC_FORBIDDEN) {
-                    // render page with root session
-                    system = true;
-                }
+                boolean system = (code == HttpServletResponse.SC_UNAUTHORIZED || code == HttpServletResponse.SC_FORBIDDEN);
+                // render page with root session
                 return render(requestWrapper, response, urlResolver, sitePath, code, system);
             } else {
                 if (LOGGER.isDebugEnabled()) {
@@ -99,15 +97,26 @@ public class ErrorPageHandler implements ErrorHandler {
 
     public boolean render(final HttpServletRequest request, final HttpServletResponse response, final URLResolver urlResolver, final String sitePath, final int errorStatus, boolean system) {
         try {
+            Locale locale = urlResolver.getLocale();
+            Iterator requestLocale = request.getLocales().asIterator();
+            JahiaSite siteByKey = siteService.getSiteByKey(StringUtils.substringAfterLast(sitePath, "/"));
+            List<Locale> languagesAsLocales = siteByKey.getLanguagesAsLocales();
+            while (requestLocale.hasNext()) {
+                Locale next = (Locale) requestLocale.next();
+                if (languagesAsLocales.contains(next)) {
+                    locale = next;
+                    break;
+                }
+            }
             if (system) {
                 // render page with root session
-                return JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(errorPageService.lookupRootUser().getJahiaUser(), urlResolver.getWorkspace(), urlResolver.getLocale(), (JCRSessionWrapper session) -> render(session, request, response, urlResolver, sitePath, errorStatus));
+                return JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(errorPageService.lookupRootUser().getJahiaUser(), urlResolver.getWorkspace(), locale, (JCRSessionWrapper session) -> render(session, request, response, urlResolver, sitePath, errorStatus));
             } else {
                 // render page with current user session
-                JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(urlResolver.getWorkspace(), urlResolver.getLocale(), null);
+                JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(urlResolver.getWorkspace(), locale, null);
                 return render(session, request, response, urlResolver, sitePath, errorStatus);
             }
-        } catch (RepositoryException e) {
+        } catch (RepositoryException | JahiaException e) {
             LOGGER.error(String.format("Error while rendering an error page for the code %d", errorStatus), e);
         }
         return false;
@@ -116,26 +125,29 @@ public class ErrorPageHandler implements ErrorHandler {
     public boolean render(JCRSessionWrapper session, HttpServletRequest request, HttpServletResponse response, URLResolver urlResolver, String sitePath, int errorStatus) {
         try {
             JCRNodeWrapper node = errorPageService.getSettingsNode(session, sitePath);
-            if (node != null && node.hasNode(String.valueOf(errorStatus))) {
-                node = node.getNode(String.valueOf(errorStatus));
-                if (node.hasProperty(ErrorPageService.ERROR_PAGE_TARGET)) {
-                    node = (JCRNodeWrapper) node.getProperty(ErrorPageService.ERROR_PAGE_TARGET).getNode();
-                    JCRSiteNode site = (JCRSiteNode) session.getNode(sitePath);
+            if (node != null) {
+                String errorStatusString = String.valueOf(errorStatus);
+                if (node.hasNode(errorStatusString)) {
+                    node = node.getNode(errorStatusString);
+                    if (node.hasProperty(ErrorPageService.ERROR_PAGE_TARGET)) {
+                        node = (JCRNodeWrapper) node.getProperty(ErrorPageService.ERROR_PAGE_TARGET).getNode();
+                        JCRSiteNode site = (JCRSiteNode) session.getNode(sitePath);
 
-                    RenderContext renderContext = errorPageService.createRenderContext(request, response, session.getUser());
-                    renderContext.setWorkspace(urlResolver.getWorkspace());
-                    renderContext.setSiteInfo(urlResolver.getSiteInfo());
-                    renderContext.setSite(site);
+                        RenderContext renderContext = errorPageService.createRenderContext(request, response, session.getUser());
+                        renderContext.setWorkspace(urlResolver.getWorkspace());
+                        renderContext.setSiteInfo(urlResolver.getSiteInfo());
+                        renderContext.setSite(site);
 
-                    Resource resource = new Resource(node, "html", null, Resource.CONFIGURATION_PAGE);
-                    renderContext.setMainResource(resource);
+                        Resource resource = new Resource(node, "html", null, Resource.CONFIGURATION_PAGE);
+                        renderContext.setMainResource(resource);
 
-                    String out = RenderService.getInstance().render(resource, renderContext).trim();
-                    response.setHeader("Content-Type", "text/html");
-                    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-                    response.setStatus(errorStatus);
-                    response.getOutputStream().write(out.getBytes(StandardCharsets.UTF_8));
-                    return true;
+                        String out = RenderService.getInstance().render(resource, renderContext).trim();
+                        response.setHeader("Content-Type", "text/html");
+                        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+                        response.setStatus(errorStatus);
+                        response.getOutputStream().write(out.getBytes(StandardCharsets.UTF_8));
+                        return true;
+                    }
                 }
             }
         } catch (ItemNotFoundException e) {
@@ -152,5 +164,9 @@ public class ErrorPageHandler implements ErrorHandler {
 
     public void setUrlResolverFactory(URLResolverFactory urlResolverFactory) {
         this.urlResolverFactory = urlResolverFactory;
+    }
+
+    public void setSiteService(JahiaSitesService siteService) {
+        this.siteService = siteService;
     }
 }

--- a/src/main/resources/META-INF/spring/site-settings-error-pages.xml
+++ b/src/main/resources/META-INF/spring/site-settings-error-pages.xml
@@ -10,5 +10,6 @@
 	<bean class="org.jahia.modules.errorpages.handler.ErrorPageHandler">
 		<property name="urlResolverFactory" ref="urlResolverFactory" />
 		<property name="errorPageService" ref="errorPageService" />
+		<property name="siteService" ref="JahiaSitesService" />
 	</bean>
 </beans>


### PR DESCRIPTION
If servername does not match anything render error pages from default site

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://support.jahia.com/browse/STIBCLOUD-53



